### PR TITLE
a11y: accessible naming

### DIFF
--- a/imagemaker.js
+++ b/imagemaker.js
@@ -253,8 +253,10 @@ window.addEventListener('load', function(ev) {
 		let noneButtonIcon = document.createElement('img');
 		noneButtonIcon.src = assetsPath + "none_button.svg";
 		noneButton.appendChild(noneButtonIcon);
+		noneButtonIcon.alt = "none";
 		document.getElementById("itemlist_list").appendChild(noneButton);
 		noneButton.style.display = "none";
+		
 		itemsElements[i][0] = noneButton;
  	    }
 	    for (let j = 0; j < parts[i].items.length; j++) {

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -266,6 +266,7 @@ window.addEventListener('load', function(ev) {
 		itemIcon.src = (assetsPath +
 				parts[i].folder + "/" +
 				parts[i].items[j] + ".png");
+		itemIcon.alt = parts[i].items[j].toString();
 		item.appendChild(itemIcon);
 		item.id = "item_" + i.toString() + "_" + j.toString();
 		item.style.display = "none";

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -113,6 +113,7 @@ window.addEventListener('load', function(ev) {
 		});
 		colorElement.id = "color_" + i.toString() + "_" + j.toString();
 		colorElement.style.display = "none";
+		colorElement.ariaLabel = parts[i].folder.toString() + " " + ntc.name(parts[i].colors[j])[1];
 		document.getElementById("colorpalette_list").appendChild(colorElement);
 	    }
 	}
@@ -266,7 +267,7 @@ window.addEventListener('load', function(ev) {
 		itemIcon.src = (assetsPath +
 				parts[i].folder + "/" +
 				parts[i].items[j] + ".png");
-		itemIcon.alt = parts[i].items[j].toString();
+		itemIcon.alt = parts[i].folder + " " +parts[i].items[j].toString();
 		item.appendChild(itemIcon);
 		item.id = "item_" + i.toString() + "_" + j.toString();
 		item.style.display = "none";

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -231,6 +231,7 @@ window.addEventListener('load', function(ev) {
 	    part.appendChild(partIcon);
 	    part.id = "part_" + i.toString();
             document.getElementById('parts_list').appendChild(part);
+		partIcon.alt = parts[i].folder.toString()
 	    partsElements[i] = part;
 	}
 	return null;

--- a/index.css
+++ b/index.css
@@ -500,7 +500,7 @@ body {
     -webkit-overflow-scrolling: touch;
 }
 
-.imagemaker_colorpalette ul {
+.imagemaker_colorpalette div {
     padding: 0;
     font-size: 0;
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 </head>
 
 <body>
+	<script src="
+	https://chir.ag/projects/ntc/ntc.js"></script>
 	<script src="imagemaker.js"></script>
 	<header>
 		<h1>Character Builder</h1>
@@ -48,8 +50,8 @@
 								</div>
 							</div>
 							<div id="imagemaker_colorpalette" class="imagemaker_colorpalette">
-								<ul id="colorpalette_list">
-								</ul>
+								<div id="colorpalette_list">
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Suggested changes

This branch provides alt text and aria labelling to elements in the interface that were lacking them. Whenever possible, the alt text is created programmatically based off the information provided in the image and folder structure in the `imagemaker.js` file.

- Items menu buttons obtain their accessible names from the folder their image assets come from
- Item selection buttons have alt text composed of the name of the item/setting in their file name, along with the name of the folder. the result is we get names like `Ears Big` or `Tail Long`. This felt stronger than just putting the `Big` or `Long` with no additional context.
- Color swatch options have an aria label applied that appends the folder name with the hex being used converted into its nearest CSS color keyword. the end result here is accessible names like `Ears White` or `Eyes Turquoise`. this is made possible by the [Name That Color Javascript Library](https://chir.ag/projects/ntc/)

## Screenshots

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/55950243-763b-488f-b8bd-06dac047a2d3">

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/8f2858c0-f994-40ab-a9fc-5b4670a31316">


<img width="1253" alt="image" src="https://github.com/user-attachments/assets/068ff248-3d86-4f89-b36d-f298f8e9e423">

